### PR TITLE
hnsd: add Dockerfile for build and deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine AS builder
+RUN apk add \
+	autoconf \
+	libtool \
+	automake \
+	g++ \
+	make \
+	libuv \
+	unbound-dev 
+
+COPY . .
+RUN ./autogen.sh && ./configure && make
+RUN cat config.log
+
+FROM alpine AS hnsd
+RUN apk add --no-cache unbound
+COPY --from=builder hnsd .
+# Authoritative Resolver
+EXPOSE 5359/udp
+# Recursive Resolver
+EXPOSE 5360/udp
+ENTRYPOINT ["./hnsd", "--ns-host=0.0.0.0:5359", "--rs-host=0.0.0.0:5360"]
+
+# Some arbitrary working seeds, since the default testnet ones are down.
+CMD [\
+"--seeds=\
+ak2hy7feae2o5pfzsdzw3cxkxsu3lxypykcl6iphnup4adf2ply6a@138.68.61.31:13038,\
+ajaqq7jwqrwixmvl64tzi3qfi7ynj3hmmtzmkyubtrljh4mwmh7ie@165.22.151.242:13038,\
+"\
+]


### PR DESCRIPTION
This is a Dockerfile to reproducibly build a minimal (7 MB) linux image (currently published at [nambase/hnsd](https://cloud.docker.com/u/namebase/repository/docker/namebase/hnsd))

@turbomaze If you link this GitHub org to [Docker Hub](https://cloud.docker.com/u/namebase/repository/docker/namebase/hnsd/builds), we can have it automatically build and release images.

Build `latest` and `0.0.0` tags with `docker build -t namebase/hnsd -t namebase/hnsd:0.0.0 .`

Push tags to Docker Hub with `docker push namebase/hnsd`

Run local recursive resolver on `$PORT` with `docker run -p 5360:$PORT/udp namebase/hnsd` (you can also pass any normal `hnsd` arguments here as well)